### PR TITLE
[NOT TO BE MERGED] fix for ruby 322

### DIFF
--- a/lib/lockbox.rb
+++ b/lib/lockbox.rb
@@ -92,7 +92,7 @@ module Lockbox
     str.unpack("H*").first
   end
 
-  def self.new(**options)
-    Encryptor.new(**options)
+  def self.new(options={})
+    Encryptor.new(options)
   end
 end

--- a/lib/lockbox/encryptor.rb
+++ b/lib/lockbox/encryptor.rb
@@ -1,6 +1,6 @@
 module Lockbox
   class Encryptor
-    def initialize(**options)
+    def initialize(options={})
       options = Lockbox.default_options.merge(options)
       @encode = options.delete(:encode)
       # option may be renamed to binary: true


### PR DESCRIPTION
### Description: ###

We've been relying on lockbox 0.3.7 for attr_encyprted gem. However, with ruby 3 upgrade, it had two issues.

1. 0.3.7 is not compatible with ruby 3.
2. anything beyond 0.3.7, [they dropped these important class methods](https://github.com/ankane/lockbox/blob/bdb34802b5743f73aa5fefc4a2cd2dc2ac7de698/lib/lockbox/encryptor.rb#L86C5-L96C8) we need.


### What to do with this branch? ###

For now, the guest-server is relying on this branch 🤔  once we confirm this fix works for our service, we can

1. merge it to master of this forked repo with a new version number such as 0.3.7.1
2. leave it like this until we know what to do with it.